### PR TITLE
Add async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Version `^2.0.0` of this plugin is compatible with webpack `^4.0.0`. If you're u
 npm install event-hooks-webpack-plugin --save-dev
 ```
 
-## Usage
+## Synchronous Usage
+
 ```js
 const EventHooksPlugin = require('event-hooks-webpack-plugin');
 
@@ -26,7 +27,46 @@ module.exports = {
             }
         })
     ]
-}
+};
+```
+
+## Asynchronous Usage
+
+### Callbacks
+
+```js
+const EventHooksPlugin = require('event-hooks-webpack-plugin');
+const { EventPluginCallbackTask } = require('event-hooks-webpack-plugin/tasks');
+
+module.exports = {
+  // ...
+  plugins: [
+    new EventHooksPlugin({
+      'eventName': new EventHooksPluginCallbackTask((compiler, callback) => {
+        // ...
+        callback();
+      })
+    })
+  ]
+};
+```
+
+### Promises
+
+```js
+const EventHooksPlugin = require('event-hooks-webpack-plugin');
+const { EventPluginPromiseTask } = require('event-hooks-webpack-plugin/tasks');
+
+module.exports = {
+  // ...
+  plugins: [
+    new EventHooksPlugin({
+      'eventName': new EventHooksPluginPromiseTask(async compiler => {
+        // ...
+      })
+    })
+  ]
+};
 ```
 
 ## Options

--- a/examples/async/src/index.js
+++ b/examples/async/src/index.js
@@ -1,0 +1,1 @@
+// This file is intentionally left blank

--- a/examples/async/webpack.config.js
+++ b/examples/async/webpack.config.js
@@ -1,0 +1,24 @@
+const EventHooksPlugin = require('../../lib/');
+const {
+  EventHooksPluginCallbackTask,
+  EventHooksPluginPromiseTask
+} = require('../../lib/hooks');
+
+module.exports = {
+  plugins: [
+    new EventHooksPlugin({
+      run: new EventHooksPluginCallbackTask((compiler, callback) => {
+        console.log('Starting callback task');
+        setTimeout(() => {
+          console.log('Finished callback task');
+          callback();
+        }, 2000);
+      }),
+      done: new EventHooksPluginPromiseTask(async compiler => {
+        console.log('Starting promise task');
+        await new Promise(r => setTimeout(r, 2000));
+        console.log('Finished promise task');
+      })
+    })
+  ]
+};

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,27 @@
+/* Exists for symmetry with other task classes, users are encouraged to use simple functions instead */
+class EventHooksPluginTask {
+  constructor(task) {
+    this.tap = 'tap';
+    this.task = task;
+  }
+}
+
+class EventHooksPluginPromiseTask {
+  constructor(task) {
+    this.tap = 'tapPromise';
+    this.task = task;
+  }
+}
+
+class EventHooksPluginCallbackTask {
+  constructor(task) {
+    this.tap = 'tapAsync';
+    this.task = task;
+  }
+}
+
+module.exports = {
+  EventHooksPluginTask,
+  EventHooksPluginPromiseTask,
+  EventHooksPluginCallbackTask
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,11 @@ module.exports = class EventHooksPlugin {
                 throw new InvalidHookNameError(`Invalid hook name '${hook}', use one of '${validHookNames.join(', ')}'`);
             }
 
-            compiler.hooks[hook].tap(plugin, hooks[hook]);
+          const task = hooks[hook];
+          const tap = typeof task === "function" ? "tap" : task.tap;
+          const fn = typeof task === "function" ? task : task.hook;
+
+          compiler.hooks[hook][tap](plugin, fn);
         });
     }
 };

--- a/tests/webpack.test.js
+++ b/tests/webpack.test.js
@@ -1,5 +1,10 @@
 import webpack from 'webpack';
 import EventHooksPlugin from '../lib/';
+import {
+  EventHooksPluginCallbackTask,
+  EventHooksPluginPromiseTask,
+  EventHooksPluginTask
+} from '../lib/hooks';
 
 it('Throws a meaningful message when providing an invalid event hook name', () => {
     expect(() => {
@@ -11,4 +16,82 @@ it('Throws a meaningful message when providing an invalid event hook name', () =
             ]
         });
     }).toThrow(/Invalid hook name/);
+});
+
+describe('Delegates to compiler', () => {
+  const tap = jest.fn();
+  const tapAsync = jest.fn();
+  const tapPromise = jest.fn();
+
+  const compiler = {
+    hooks: {
+      start: {
+        tap,
+        tapAsync,
+        tapPromise
+      }
+    }
+  };
+
+  afterEach(() => {
+    tap.mockReset();
+    tapPromise.mockReset();
+    tapAsync.mockReset();
+  });
+
+  it('Functions to #tap', () => {
+    const hooks = {
+      start: () => null
+    };
+
+    const plugin = new EventHooksPlugin(hooks);
+
+    plugin.apply(compiler);
+
+    expect(tap).toHaveBeenCalled();
+    expect(tapPromise).not.toHaveBeenCalled();
+    expect(tapAsync).not.toHaveBeenCalled();
+  });
+
+  it('EventHooksPluginTask to #tap', () => {
+    const hooks = {
+      start: new EventHooksPluginTask(compiler => null)
+    };
+
+    const plugin = new EventHooksPlugin(hooks);
+
+    plugin.apply(compiler);
+
+    expect(tap).toHaveBeenCalled();
+    expect(tapPromise).not.toHaveBeenCalled();
+    expect(tapAsync).not.toHaveBeenCalled();
+  });
+
+  it('EventHooksPluginPromiseTask to #tapPromise', () => {
+    const hooks = {
+      start: new EventHooksPluginPromiseTask(async compiler => null)
+    };
+
+    const plugin = new EventHooksPlugin(hooks);
+
+    plugin.apply(compiler);
+
+    expect(tap).not.toHaveBeenCalled();
+    expect(tapPromise).toHaveBeenCalled();
+    expect(tapAsync).not.toHaveBeenCalled();
+  });
+
+  it('EventHooksPluginTask to #tapAsync', () => {
+    const hooks = {
+      start: new EventHooksPluginCallbackTask((compiler, cb) => cb())
+    };
+
+    const plugin = new EventHooksPlugin(hooks);
+
+    plugin.apply(compiler);
+
+    expect(tap).not.toHaveBeenCalled();
+    expect(tapPromise).not.toHaveBeenCalled();
+    expect(tapAsync).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
First off, thank you for creating this plugin :+1:

## What is the motivation for this PR?
Plugin users would benefit from having the option to run asynchronous code in the event hook.

## Changes summary
Brings asynchronous support for event hooks without any breaking changes  :fire:  :fire:  :fire: 


## Example Usage
Since there are no breaking changes, users can continue using the plugin as is.

```javascript
new EventHooksPlugin({
   'eventName': () => {
       // some synchronous code
   }
})
```
However, if this is merged we can have async handlers for the events.

```javascript
new EventHooksPlugin({
   'eventName': new EventHandlerPluginCallbackTask((compiler, callback) => {
       // some asynchronous code
       callback();
   })
})
```
```javascript
new EventHooksPlugin({
   'eventName': new EventHandlerPluginPromiseTask(async compiler => {
       // some asynchronous code
   })
})
```

## Implementation details

The current implementation delegates to webpack's `compiler.hooks[eventName].tap` method. This PR allows for delegating to `compiler.hooks[eventName].tapAsync` and `compiler.hooks[eventName].tapPromise` by exposing `EventHandlerPluginCallbackTask` and `EventHandlerPluginPromiseTask` classes to the end user. 

We use classes, because we cannot deduce the return type of the hook passed in by the user wihtout invoking the hook. So we ask the user to declare the intent up front by newing up one of the handler classes.
